### PR TITLE
fix: update pyproject.toml to resolve packaging error

### DIFF
--- a/Python/pyproject.toml
+++ b/Python/pyproject.toml
@@ -1,10 +1,21 @@
 [project]
-name = "unity"
+name = "unity-mcp"
 version = "0.1.0"
-description = "Add your description here"
+description = "Unity MCP Server: A Unity package for Unity Editor integration via the Model Context Protocol (MCP)."
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "httpx>=0.28.1",
-    "mcp[cli]>=1.4.1",
+  "httpx>=0.28.1",
+  "mcp[cli]>=1.4.1"
 ]
+
+[build-system]
+requires = ["setuptools>=42", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+# These are the single-file modules at the root of the Python folder.
+py-modules = ["config", "server", "unity_connection"]
+
+# The "tools" subdirectory is a package.
+packages = ["tools"]


### PR DESCRIPTION
The installation was failing due to setuptools discovering multiple top-level modules in the flat project layout. This commit updates the pyproject.toml by explicitly specifying:
  
• The standalone modules ("config.py", "server.py", "unity_connection.py") via the py-modules field.   • The "tools" directory as a package via the packages field.
  
These changes resolve the "multiple top-level modules discovered" error encountered during `uv pip install -e .` and ensure a clean, predictable package build.