### PR TITLE
Optionally connect to places other than localhost

### DIFF
--- a/UnityMcpBridge/Editor/Windows/UnityMcpEditorWindow.cs.meta
+++ b/UnityMcpBridge/Editor/Windows/UnityMcpEditorWindow.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4283e255b343c4546b843cd22214ac93

--- a/UnityMcpServer/src/Dockerfile
+++ b/UnityMcpServer/src/Dockerfile
@@ -22,6 +22,8 @@ COPY tools/ /app/tools/
 # Install dependencies using uv
 RUN uv pip install --system -e .
 
+# Create a simple entrypoint script to run the server with any provided arguments
+RUN echo '#!/bin/sh\nexec uv run server.py "$@"' > /app/entrypoint.sh && chmod +x /app/entrypoint.sh
 
-# Command to run the server
-CMD ["uv", "run", "server.py"] 
+# Use the entrypoint script
+ENTRYPOINT ["/app/entrypoint.sh"] 

--- a/UnityMcpServer/src/README.docker.md
+++ b/UnityMcpServer/src/README.docker.md
@@ -1,0 +1,66 @@
+# Unity MCP Server - Docker Setup
+
+This repository contains Docker configuration for running the Unity MCP server in a container.
+
+## Prerequisites
+
+- [Podman](https://podman.io/get-started) or [Docker](https://docs.docker.com/get-docker/)
+- Unity Editor with the Unity MCP Bridge package installed
+
+## Getting Started
+
+### 1. Build and Start the Docker Container
+
+```bash
+docker build -t unity-mcp:latest
+```
+
+This will build the Docker image and start the Unity MCP server in a container.
+
+### 2. Configure Your MCP Client
+
+Configure your MCP client (Claude, Cursor, etc.) to use the dockerized server:
+
+```json
+{
+  "mcpServers": {
+    "UnityMCP": {
+      "command": "docker",
+      "args": [
+        "run",
+        "--rm",
+        "--name",
+        "unity-mcp-server",
+        "--unity-host=host.docker.internal",
+        "--unity-port=6400"
+      ]
+    }
+  }
+}
+```
+
+```json
+{
+  "mcpServers": {
+    "UnityMCP": {
+      "command": "podman",
+      "args": [
+        "run",
+        "--rm",
+        "--name",
+        "unity-mcp-server",
+        "--unity-host=host.container.internal",
+        "--unity-port=6400"
+      ]
+    }
+  }
+}
+```
+
+## Stopping the Container
+
+To stop the container:
+
+```bash
+docker stop unity-mcp-server
+``` 

--- a/UnityMcpServer/src/config.py
+++ b/UnityMcpServer/src/config.py
@@ -3,6 +3,7 @@ Configuration settings for the Unity MCP Server.
 This file contains all configurable parameters for the server.
 """
 
+import argparse
 from dataclasses import dataclass
 
 @dataclass
@@ -26,5 +27,24 @@ class ServerConfig:
     max_retries: int = 3
     retry_delay: float = 1.0
 
-# Create a global config instance
-config = ServerConfig() 
+# Parse command line arguments
+def parse_args():
+    parser = argparse.ArgumentParser(description='Unity MCP Server')
+    parser.add_argument('--unity-host', dest='unity_host', type=str, default="localhost",
+                        help='Host address of Unity Editor (default: localhost)')
+    parser.add_argument('--unity-port', dest='unity_port', type=int, default=6400,
+                        help='Port number of Unity Editor (default: 6400)')
+    parser.add_argument('--log-level', dest='log_level', type=str, default="INFO",
+                        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+                        help='Logging level (default: INFO)')
+    return parser.parse_args()
+
+# Create a global config instance with default values
+config = ServerConfig()
+
+# This will be called from server.py to update the config with command line arguments
+def load_config_from_args():
+    args = parse_args()
+    config.unity_host = args.unity_host
+    config.unity_port = args.unity_port
+    config.log_level = args.log_level 

--- a/UnityMcpServer/src/server.py
+++ b/UnityMcpServer/src/server.py
@@ -3,9 +3,12 @@ import logging
 from dataclasses import dataclass
 from contextlib import asynccontextmanager
 from typing import AsyncIterator, Dict, Any, List
-from config import config
+from config import config, load_config_from_args
 from tools import register_all_tools
 from unity_connection import get_unity_connection, UnityConnection
+
+# Load config from command line arguments
+load_config_from_args()
 
 # Configure logging using settings from config
 logging.basicConfig(
@@ -13,6 +16,7 @@ logging.basicConfig(
     format=config.log_format
 )
 logger = logging.getLogger("unity-mcp-server")
+logger.info(f"Starting server with Unity connection to {config.unity_host}:{config.unity_port}")
 
 # Global connection state
 _unity_connection: UnityConnection = None

--- a/UnityMcpServer/src/unity_connection.py
+++ b/UnityMcpServer/src/unity_connection.py
@@ -29,6 +29,7 @@ class UnityConnection:
             logger.info(f"Connected to Unity at {self.host}:{self.port}")
             return True
         except Exception as e:
+            logger.error(f"Failed to connect to on {self.host}:{self.port}")
             logger.error(f"Failed to connect to Unity: {str(e)}")
             self.sock = None
             return False
@@ -181,7 +182,7 @@ def get_unity_connection() -> UnityConnection:
     
     # Create a new connection
     logger.info("Creating new Unity connection")
-    _unity_connection = UnityConnection()
+    _unity_connection = UnityConnection(host=config.unity_host, port=config.unity_port)
     if not _unity_connection.connect():
         _unity_connection = None
         raise ConnectionError("Could not connect to Unity. Ensure the Unity Editor and MCP Bridge are running.")


### PR DESCRIPTION
This change allows the user to select listening on 0.0.0.0 instead of only loopback.  Loopback is left as the default and the python portion's default assumes the hardcoded port on localhost unless cli arguments are passed.  Dockerfile (see #108 ) has been updated to pass cli arguments.


### Added
- Network Interface Configuration in Unity MCP Bridge
  - Added toggle option to listen on all network interfaces (0.0.0.0) vs. loopback only (127.0.0.1)
  - Added display of available IP addresses in the editor window
  - Added persistence of network interface settings using EditorPrefs
  - Added helper method to discover available IP addresses on the machine

- Docker Support for UnityMcpServer
  - Added command-line parameters to specify Unity host and port
  - Added `--unity-host` parameter to connect to specific Unity Editor hostname/IP
  - Added `--unity-port` parameter to specify custom port
  - Added `--log-level` parameter to control logging verbosity
  - Added README.docker.md with Docker configuration instructions
  - Added configuration examples for both Docker and Podman

### Changed
- Modified UnityMcpBridge to support binding to all interfaces
- Updated Dockerfile to use a flexible ENTRYPOINT that accepts command-line arguments
- Enhanced connection logging to show the host and port being used
- Updated UnityMcpServer to explicitly use command-line parameters
- Improved error messages with more diagnostic information

### Security
- Added warning message when listening on all interfaces
- Default binding remains on loopback only (127.0.0.1) for security
- Added documentation about security implications of network exposure 