### PR TITLE
fix: resolve menu execution failure by unifying parameter names  fixes #116

### DIFF
--- a/UnityMcpBridge/Editor/Tools/ExecuteMenuItem.cs
+++ b/UnityMcpBridge/Editor/Tools/ExecuteMenuItem.cs
@@ -66,13 +66,13 @@ namespace UnityMcpBridge.Editor.Tools
         /// </summary>
         private static object ExecuteItem(JObject @params)
         {
-            string menuPath = @params["menu_path"]?.ToString();
+            string menuPath = @params["menuPath"]?.ToString();
             // string alias = @params["alias"]?.ToString(); // TODO: Implement alias mapping based on refactor plan requirements.
             // JObject parameters = @params["parameters"] as JObject; // TODO: Investigate parameter passing (often not directly supported by ExecuteMenuItem).
 
             if (string.IsNullOrWhiteSpace(menuPath))
             {
-                return Response.Error("Required parameter 'menu_path' is missing or empty.");
+                return Response.Error("Required parameter 'menuPath' is missing or empty.");
             }
 
             // Validate against blacklist


### PR DESCRIPTION
Fixes #116 

Unified parameter name from "menu_path" to "menuPath" in ExecuteMenuItem.cs, resolving the parameter name mismatch that caused menu items to fail execution.

The issue occurred due to inconsistent naming styles between parameter reception and validation - code expected "menuPath" but error message used "menu_path", causing errors even when clients passed the correct parameter.