### PR TITLE
Feature: VSCode GitHub Copilot Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ CONTRIBUTING.md.meta
 .idea/
 .vscode/
 .aider*
+.DS_Store*

--- a/UnityMcpBridge/Editor/Data/McpClients.cs
+++ b/UnityMcpBridge/Editor/Data/McpClients.cs
@@ -43,6 +43,26 @@ namespace UnityMcpBridge.Editor.Data
                 mcpType = McpTypes.Cursor,
                 configStatus = "Not Configured",
             },
+            new()
+            {
+                name = "VSCode GitHub Copilot",
+                windowsConfigPath = Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                    "Code",
+                    "User",
+                    "settings.json"
+                ),
+                linuxConfigPath = Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                    "Library",
+                    "Application Support",
+                    "Code",
+                    "User",
+                    "settings.json"
+                ),
+                mcpType = McpTypes.VSCode,
+                configStatus = "Not Configured",
+            },
         };
 
         // Initialize status enums after construction

--- a/UnityMcpBridge/Editor/Models/McpTypes.cs
+++ b/UnityMcpBridge/Editor/Models/McpTypes.cs
@@ -4,6 +4,7 @@ namespace UnityMcpBridge.Editor.Models
     {
         ClaudeDesktop,
         Cursor,
+        VSCode,
     }
 }
 

--- a/UnityMcpBridge/Editor/Windows/ManualConfigEditorWindow.cs
+++ b/UnityMcpBridge/Editor/Windows/ManualConfigEditorWindow.cs
@@ -8,13 +8,13 @@ namespace UnityMcpBridge.Editor.Windows
     // Editor window to display manual configuration instructions
     public class ManualConfigEditorWindow : EditorWindow
     {
-        private string configPath;
-        private string configJson;
-        private Vector2 scrollPos;
-        private bool pathCopied = false;
-        private bool jsonCopied = false;
-        private float copyFeedbackTimer = 0;
-        private McpClient mcpClient;
+        protected string configPath;
+        protected string configJson;
+        protected Vector2 scrollPos;
+        protected bool pathCopied = false;
+        protected bool jsonCopied = false;
+        protected float copyFeedbackTimer = 0;
+        protected McpClient mcpClient;
 
         public static void ShowWindow(string configPath, string configJson, McpClient mcpClient)
         {
@@ -26,7 +26,7 @@ namespace UnityMcpBridge.Editor.Windows
             window.Show();
         }
 
-        private void OnGUI()
+        protected virtual void OnGUI()
         {
             scrollPos = EditorGUILayout.BeginScrollView(scrollPos);
 
@@ -245,7 +245,7 @@ namespace UnityMcpBridge.Editor.Windows
             EditorGUILayout.EndScrollView();
         }
 
-        private void Update()
+        protected virtual void Update()
         {
             // Handle the feedback message timer
             if (copyFeedbackTimer > 0)

--- a/UnityMcpBridge/Editor/Windows/UnityMcpEditorWindow.cs
+++ b/UnityMcpBridge/Editor/Windows/UnityMcpEditorWindow.cs
@@ -168,7 +168,7 @@ namespace UnityMcpBridge.Editor.Windows
                         {
                             servers = new
                             {
-                                UnityMCP = new
+                                unityMCP = new
                                 {
                                     command = "uv",
                                     args = new[] { "--directory", pythonDir, "run", "server.py" }
@@ -180,6 +180,7 @@ namespace UnityMcpBridge.Editor.Windows
                     JsonSerializerSettings jsonSettings = new() { Formatting = Formatting.Indented };
                     string manualConfigJson = JsonConvert.SerializeObject(vscodeConfig, jsonSettings);
                     
+                    // Use the VSCodeManualSetupWindow directly since we're in the same namespace
                     VSCodeManualSetupWindow.ShowWindow(configPath, manualConfigJson);
                 }
             }
@@ -653,7 +654,7 @@ namespace UnityMcpBridge.Editor.Windows
                             var args = config.mcp.servers.unityMCP.args.ToObject<string[]>();
                             
                             if (pythonDir != null && 
-                                Array.Exists(args, arg => arg.Contains(pythonDir, StringComparison.Ordinal)))
+                                Array.Exists(args, new Predicate<string>(arg => arg.Contains(pythonDir, StringComparison.Ordinal))))
                             {
                                 mcpClient.SetStatus(McpStatus.Configured);
                             }

--- a/UnityMcpBridge/Editor/Windows/VSCodeManualSetupWindow.cs
+++ b/UnityMcpBridge/Editor/Windows/VSCodeManualSetupWindow.cs
@@ -7,14 +7,6 @@ namespace UnityMcpBridge.Editor.Windows
 {
     public class VSCodeManualSetupWindow : ManualConfigEditorWindow
     {
-        // Not defining fields that are inherited from ManualConfigEditorWindow:
-        // protected string configPath;
-        // protected string configJson;
-        // protected Vector2 scrollPos;
-        // protected bool pathCopied;
-        // protected bool jsonCopied;
-        // protected float copyFeedbackTimer;
-        // protected McpClient mcpClient;
         public static new void ShowWindow(string configPath, string configJson)
         {
             var window = GetWindow<VSCodeManualSetupWindow>("VSCode GitHub Copilot Setup");

--- a/UnityMcpBridge/Editor/Windows/VSCodeManualSetupWindow.cs
+++ b/UnityMcpBridge/Editor/Windows/VSCodeManualSetupWindow.cs
@@ -5,25 +5,34 @@ using UnityMcpBridge.Editor.Models;
 
 namespace UnityMcpBridge.Editor.Windows
 {
-    public class VSCodeManualSetupWindow : EditorWindow
+    public class VSCodeManualSetupWindow : ManualConfigEditorWindow
     {
-        private string configPath;
-        private string configJson;
-        private Vector2 scrollPos;
-        private bool pathCopied = false;
-        private bool jsonCopied = false;
-        private float copyFeedbackTimer = 0;
-
-        public static void ShowWindow(string configPath, string configJson)
+        // Not defining fields that are inherited from ManualConfigEditorWindow:
+        // protected string configPath;
+        // protected string configJson;
+        // protected Vector2 scrollPos;
+        // protected bool pathCopied;
+        // protected bool jsonCopied;
+        // protected float copyFeedbackTimer;
+        // protected McpClient mcpClient;
+        public static new void ShowWindow(string configPath, string configJson)
         {
-            VSCodeManualSetupWindow window = GetWindow<VSCodeManualSetupWindow>("VSCode GitHub Copilot Setup");
+            var window = GetWindow<VSCodeManualSetupWindow>("VSCode GitHub Copilot Setup");
             window.configPath = configPath;
             window.configJson = configJson;
             window.minSize = new Vector2(550, 500);
+            
+            // Create a McpClient for VSCode
+            window.mcpClient = new McpClient
+            {
+                name = "VSCode GitHub Copilot",
+                mcpType = McpTypes.VSCode
+            };
+            
             window.Show();
         }
 
-        private void OnGUI()
+        protected override void OnGUI()
         {
             scrollPos = EditorGUILayout.BeginScrollView(scrollPos);
 
@@ -133,6 +142,12 @@ namespace UnityMcpBridge.Editor.Windows
                     "User",
                     "settings.json"
                 );
+            }
+
+            // Store the path in the base class config path
+            if (string.IsNullOrEmpty(configPath))
+            {
+                configPath = displayPath;
             }
 
             // Prevent text overflow by allowing the text field to wrap
@@ -279,19 +294,10 @@ namespace UnityMcpBridge.Editor.Windows
             EditorGUILayout.EndScrollView();
         }
 
-        private void Update()
+        protected override void Update()
         {
-            // Handle the feedback message timer
-            if (copyFeedbackTimer > 0)
-            {
-                copyFeedbackTimer -= Time.deltaTime;
-                if (copyFeedbackTimer <= 0)
-                {
-                    pathCopied = false;
-                    jsonCopied = false;
-                    Repaint();
-                }
-            }
+            // Call the base implementation which handles the copy feedback timer
+            base.Update();
         }
     }
 }

--- a/UnityMcpBridge/Editor/Windows/VSCodeManualSetupWindow.cs
+++ b/UnityMcpBridge/Editor/Windows/VSCodeManualSetupWindow.cs
@@ -1,0 +1,297 @@
+using System.Runtime.InteropServices;
+using UnityEditor;
+using UnityEngine;
+using UnityMcpBridge.Editor.Models;
+
+namespace UnityMcpBridge.Editor.Windows
+{
+    public class VSCodeManualSetupWindow : EditorWindow
+    {
+        private string configPath;
+        private string configJson;
+        private Vector2 scrollPos;
+        private bool pathCopied = false;
+        private bool jsonCopied = false;
+        private float copyFeedbackTimer = 0;
+
+        public static void ShowWindow(string configPath, string configJson)
+        {
+            VSCodeManualSetupWindow window = GetWindow<VSCodeManualSetupWindow>("VSCode GitHub Copilot Setup");
+            window.configPath = configPath;
+            window.configJson = configJson;
+            window.minSize = new Vector2(550, 500);
+            window.Show();
+        }
+
+        private void OnGUI()
+        {
+            scrollPos = EditorGUILayout.BeginScrollView(scrollPos);
+
+            // Header with improved styling
+            EditorGUILayout.Space(10);
+            Rect titleRect = EditorGUILayout.GetControlRect(false, 30);
+            EditorGUI.DrawRect(
+                new Rect(titleRect.x, titleRect.y, titleRect.width, titleRect.height),
+                new Color(0.2f, 0.2f, 0.2f, 0.1f)
+            );
+            GUI.Label(
+                new Rect(titleRect.x + 10, titleRect.y + 6, titleRect.width - 20, titleRect.height),
+                "VSCode GitHub Copilot MCP Setup",
+                EditorStyles.boldLabel
+            );
+            EditorGUILayout.Space(10);
+
+            // Instructions with improved styling
+            EditorGUILayout.BeginVertical(EditorStyles.helpBox);
+
+            Rect headerRect = EditorGUILayout.GetControlRect(false, 24);
+            EditorGUI.DrawRect(
+                new Rect(headerRect.x, headerRect.y, headerRect.width, headerRect.height),
+                new Color(0.1f, 0.1f, 0.1f, 0.2f)
+            );
+            GUI.Label(
+                new Rect(
+                    headerRect.x + 8,
+                    headerRect.y + 4,
+                    headerRect.width - 16,
+                    headerRect.height
+                ),
+                "Setting up GitHub Copilot in VSCode with Unity MCP",
+                EditorStyles.boldLabel
+            );
+            EditorGUILayout.Space(10);
+
+            GUIStyle instructionStyle = new(EditorStyles.wordWrappedLabel)
+            {
+                margin = new RectOffset(10, 10, 5, 5),
+            };
+
+            EditorGUILayout.LabelField(
+                "1. Prerequisites",
+                EditorStyles.boldLabel
+            );
+            EditorGUILayout.LabelField(
+                "• Ensure you have VSCode installed",
+                instructionStyle
+            );
+            EditorGUILayout.LabelField(
+                "• Ensure you have GitHub Copilot extension installed in VSCode",
+                instructionStyle
+            );
+            EditorGUILayout.LabelField(
+                "• Ensure you have a valid GitHub Copilot subscription",
+                instructionStyle
+            );
+            EditorGUILayout.Space(5);
+            
+            EditorGUILayout.LabelField(
+                "2. Steps to Configure",
+                EditorStyles.boldLabel
+            );
+            EditorGUILayout.LabelField(
+                "a) Open VSCode Settings (File > Preferences > Settings)",
+                instructionStyle
+            );
+            EditorGUILayout.LabelField(
+                "b) Click on the 'Open Settings (JSON)' button in the top right",
+                instructionStyle
+            );
+            EditorGUILayout.LabelField(
+                "c) Add the MCP configuration shown below to your settings.json file",
+                instructionStyle
+            );
+            EditorGUILayout.LabelField(
+                "d) Save the file and restart VSCode",
+                instructionStyle
+            );
+            EditorGUILayout.Space(5);
+            
+            EditorGUILayout.LabelField(
+                "3. VSCode settings.json location:",
+                EditorStyles.boldLabel
+            );
+
+            // Path section with improved styling
+            EditorGUILayout.BeginVertical(EditorStyles.helpBox);
+            string displayPath;
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                displayPath = System.IO.Path.Combine(
+                    System.Environment.GetFolderPath(System.Environment.SpecialFolder.ApplicationData),
+                    "Code",
+                    "User",
+                    "settings.json"
+                );
+            }
+            else 
+            {
+                displayPath = System.IO.Path.Combine(
+                    System.Environment.GetFolderPath(System.Environment.SpecialFolder.UserProfile),
+                    "Library",
+                    "Application Support",
+                    "Code",
+                    "User",
+                    "settings.json"
+                );
+            }
+
+            // Prevent text overflow by allowing the text field to wrap
+            GUIStyle pathStyle = new(EditorStyles.textField) { wordWrap = true };
+
+            EditorGUILayout.TextField(
+                displayPath,
+                pathStyle,
+                GUILayout.Height(EditorGUIUtility.singleLineHeight)
+            );
+
+            // Copy button with improved styling
+            EditorGUILayout.BeginHorizontal();
+            GUILayout.FlexibleSpace();
+            GUIStyle copyButtonStyle = new(GUI.skin.button)
+            {
+                padding = new RectOffset(15, 15, 5, 5),
+                margin = new RectOffset(10, 10, 5, 5),
+            };
+
+            if (
+                GUILayout.Button(
+                    "Copy Path",
+                    copyButtonStyle,
+                    GUILayout.Height(25),
+                    GUILayout.Width(100)
+                )
+            )
+            {
+                EditorGUIUtility.systemCopyBuffer = displayPath;
+                pathCopied = true;
+                copyFeedbackTimer = 2f;
+            }
+
+            if (
+                GUILayout.Button(
+                    "Open File",
+                    copyButtonStyle,
+                    GUILayout.Height(25),
+                    GUILayout.Width(100)
+                )
+            )
+            {
+                // Open the file using the system's default application
+                System.Diagnostics.Process.Start(
+                    new System.Diagnostics.ProcessStartInfo
+                    {
+                        FileName = displayPath,
+                        UseShellExecute = true,
+                    }
+                );
+            }
+
+            if (pathCopied)
+            {
+                GUIStyle feedbackStyle = new(EditorStyles.label);
+                feedbackStyle.normal.textColor = Color.green;
+                EditorGUILayout.LabelField("Copied!", feedbackStyle, GUILayout.Width(60));
+            }
+
+            EditorGUILayout.EndHorizontal();
+            EditorGUILayout.EndVertical();
+            EditorGUILayout.Space(10);
+
+            EditorGUILayout.LabelField(
+                "4. Add this configuration to your settings.json:",
+                EditorStyles.boldLabel
+            );
+
+            // JSON section with improved styling
+            EditorGUILayout.BeginVertical(EditorStyles.helpBox);
+
+            // Improved text area for JSON with syntax highlighting colors
+            GUIStyle jsonStyle = new(EditorStyles.textArea)
+            {
+                font = EditorStyles.boldFont,
+                wordWrap = true,
+            };
+            jsonStyle.normal.textColor = new Color(0.3f, 0.6f, 0.9f); // Syntax highlighting blue
+
+            // Draw the JSON in a text area with a taller height for better readability
+            EditorGUILayout.TextArea(configJson, jsonStyle, GUILayout.Height(200));
+
+            // Copy JSON button with improved styling
+            EditorGUILayout.BeginHorizontal();
+            GUILayout.FlexibleSpace();
+
+            if (
+                GUILayout.Button(
+                    "Copy JSON",
+                    copyButtonStyle,
+                    GUILayout.Height(25),
+                    GUILayout.Width(100)
+                )
+            )
+            {
+                EditorGUIUtility.systemCopyBuffer = configJson;
+                jsonCopied = true;
+                copyFeedbackTimer = 2f;
+            }
+
+            if (jsonCopied)
+            {
+                GUIStyle feedbackStyle = new(EditorStyles.label);
+                feedbackStyle.normal.textColor = Color.green;
+                EditorGUILayout.LabelField("Copied!", feedbackStyle, GUILayout.Width(60));
+            }
+
+            EditorGUILayout.EndHorizontal();
+            EditorGUILayout.EndVertical();
+
+            EditorGUILayout.Space(10);
+            EditorGUILayout.LabelField(
+                "5. After configuration:",
+                EditorStyles.boldLabel
+            );
+            EditorGUILayout.LabelField(
+                "• Restart VSCode",
+                instructionStyle
+            );
+            EditorGUILayout.LabelField(
+                "• GitHub Copilot will now be able to interact with your Unity project through the MCP protocol",
+                instructionStyle
+            );
+            EditorGUILayout.LabelField(
+                "• Remember to have the Unity MCP Bridge running in Unity Editor",
+                instructionStyle
+            );
+
+            EditorGUILayout.EndVertical();
+
+            EditorGUILayout.Space(10);
+
+            // Close button at the bottom
+            EditorGUILayout.BeginHorizontal();
+            GUILayout.FlexibleSpace();
+            if (GUILayout.Button("Close", GUILayout.Height(30), GUILayout.Width(100)))
+            {
+                Close();
+            }
+            GUILayout.FlexibleSpace();
+            EditorGUILayout.EndHorizontal();
+
+            EditorGUILayout.EndScrollView();
+        }
+
+        private void Update()
+        {
+            // Handle the feedback message timer
+            if (copyFeedbackTimer > 0)
+            {
+                copyFeedbackTimer -= Time.deltaTime;
+                if (copyFeedbackTimer <= 0)
+                {
+                    pathCopied = false;
+                    jsonCopied = false;
+                    Repaint();
+                }
+            }
+        }
+    }
+}

--- a/UnityMcpBridge/Editor/Windows/VSCodeManualSetupWindow.cs.meta
+++ b/UnityMcpBridge/Editor/Windows/VSCodeManualSetupWindow.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 377fe73d52cf0435fabead5f50a0d204


### PR DESCRIPTION
This pull request introduces support for configuring and managing the VSCode GitHub Copilot client within the `UnityMcpBridge` project. Key changes include adding a new `McpTypes` entry for VSCode, implementing VSCode-specific configuration logic, and updating the editor UI to handle VSCode-specific scenarios.

### New VSCode Client Support:
* Added a new `McpClient` entry for "VSCode GitHub Copilot" with platform-specific configuration paths in `McpClients.cs`.
* Introduced a new `McpTypes` enum value `VSCode` to distinguish VSCode clients.

### VSCode-Specific Configuration Logic:
* Updated the `WriteToConfig` method to handle VSCode-specific configuration formats, ensuring proper structure for `mcp.servers.unityMCP`.
* Enhanced the `CheckMcpConfiguration` method to validate VSCode configurations and handle differences in configuration structure compared to other clients.

### Editor UI Enhancements:
* Modified `UnityMcpEditorWindow` to provide a dedicated "Auto Configure" button and manual setup instructions for VSCode clients. The manual setup includes generating a VSCode-specific user configuration JSON:
```
"mcp": {
    "servers": {
      "unityMCP": {
        "command": "uv",
        "args": [
          "--directory",
          "/usr/local/bin/UnityMCP/UnityMcpServer/src",
          "run",
          "server.py"
        ]
      }
    }
  }
```
* Updated the `ManualConfigEditorWindow` class to allow inheritance by making its fields and methods `protected`, enabling potential extension for VSCode-specific manual setup windows. 