### PR TITLE
Add Gemini CLI configuration and path conversion utilities

### DIFF
--- a/UnityMcpBridge/Editor/Data/McpClients.cs
+++ b/UnityMcpBridge/Editor/Data/McpClients.cs
@@ -43,6 +43,23 @@ namespace UnityMcpBridge.Editor.Data
                 mcpType = McpTypes.Cursor,
                 configStatus = "Not Configured",
             },
+            new()
+            {
+                name = "Gemini CLI",
+                // TODO: Verify the correct config path for Gemini CLI
+                windowsConfigPath = Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                    ".gemini",
+                    "mcp.json"
+                ),
+                linuxConfigPath = Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                    ".gemini",
+                    "mcp.json"
+                ),
+                mcpType = McpTypes.GeminiCli,
+                configStatus = "Not Configured",
+            },
         };
 
         // Initialize status enums after construction

--- a/UnityMcpBridge/Editor/Helpers/PathConverter.cs
+++ b/UnityMcpBridge/Editor/Helpers/PathConverter.cs
@@ -1,0 +1,59 @@
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace UnityMcpBridge.Editor.Helpers
+{
+    public static class PathConverter
+    {
+        /// <summary>
+        /// Converts a Windows path to a WSL (Windows Subsystem for Linux) path.
+        /// </summary>
+        /// <param name="windowsPath">The Windows path to convert (e.g., "C:\Users\User\Documents").</param>
+        /// <returns>The corresponding WSL path (e.g., "/mnt/c/Users/User/Documents").</returns>
+        public static string WindowsPathToWslPath(string windowsPath)
+        {
+            if (string.IsNullOrEmpty(windowsPath))
+            {
+                return windowsPath;
+            }
+
+            // Replace backslashes with forward slashes
+            string wslPath = windowsPath.Replace("\\", "/");
+
+            // Convert drive letter (e.g., C:/ to /mnt/c/)
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && wslPath.Length >= 2 && wslPath[1] == ':')
+            {
+                char driveLetter = char.ToLower(wslPath[0]);
+                wslPath = $"/mnt/{driveLetter}{wslPath.Substring(2)}";
+            }
+
+            return wslPath;
+        }
+
+        /// <summary>
+        /// Converts a WSL path to a Windows path.
+        /// </summary>
+        /// <param name="wslPath">The WSL path to convert (e.g., "/mnt/c/Users/User/Documents").</param>
+        /// <returns>The corresponding Windows path (e.g., "C:\Users\User\Documents").</returns>
+        public static string WslPathToWindowsPath(string wslPath)
+        {
+            if (string.IsNullOrEmpty(wslPath))
+            {
+                return wslPath;
+            }
+
+            // Replace forward slashes with backslashes
+            string windowsPath = wslPath.Replace("/", "\\");
+
+            // Convert /mnt/c/ to C:\
+            if (windowsPath.StartsWith("\\mnt\\") && windowsPath.Length >= 7 && windowsPath[6] == '\\')
+            {
+                char driveLetter = char.ToUpper(windowsPath[5]);
+                windowsPath = $"{driveLetter}:\\{windowsPath.Substring(7)}";
+            }
+
+            return windowsPath;
+        }
+    }
+}

--- a/UnityMcpBridge/Editor/Models/McpTypes.cs
+++ b/UnityMcpBridge/Editor/Models/McpTypes.cs
@@ -4,6 +4,8 @@ namespace UnityMcpBridge.Editor.Models
     {
         ClaudeDesktop,
         Cursor,
+        GeminiCli,
     }
+}
 }
 

--- a/UnityMcpBridge/Editor/Windows/UnityMcpEditorWindow.cs
+++ b/UnityMcpBridge/Editor/Windows/UnityMcpEditorWindow.cs
@@ -276,11 +276,16 @@ namespace UnityMcpBridge.Editor.Windows
 
         private string WriteToConfig(string pythonDir, string configPath)
         {
+            // Convert pythonDir to WSL path if running on Windows
+            string finalPythonDir = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? PathConverter.WindowsPathToWslPath(pythonDir)
+                : pythonDir;
+
             // Create configuration object for unityMCP
             McpConfigServer unityMCPConfig = new()
             {
                 command = "uv",
-                args = new[] { "--directory", pythonDir, "run", "server.py" },
+                args = new[] { "--directory", finalPythonDir, "run", "server.py" },
             };
 
             JsonSerializerSettings jsonSettings = new() { Formatting = Formatting.Indented };
@@ -335,6 +340,11 @@ namespace UnityMcpBridge.Editor.Windows
             // Get the Python directory path using Package Manager API
             string pythonDir = FindPackagePythonDirectory();
 
+            // Convert pythonDir to WSL path if running on Windows
+            string finalPythonDir = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? PathConverter.WindowsPathToWslPath(pythonDir)
+                : pythonDir;
+
             // Create the manual configuration message
             McpConfig jsonConfig = new()
             {
@@ -343,7 +353,7 @@ namespace UnityMcpBridge.Editor.Windows
                     unityMCP = new McpConfigServer
                     {
                         command = "uv",
-                        args = new[] { "--directory", pythonDir, "run", "server.py" },
+                        args = new[] { "--directory", finalPythonDir, "run", "server.py" },
                     },
                 },
             };
@@ -547,11 +557,16 @@ namespace UnityMcpBridge.Editor.Windows
                 if (config?.mcpServers?.unityMCP != null)
                 {
                     string pythonDir = ServerInstaller.GetServerPath();
+                    // Convert pythonDir to WSL path for comparison if running on Windows
+                    string comparisonPythonDir = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                        ? PathConverter.WindowsPathToWslPath(pythonDir)
+                        : pythonDir;
+
                     if (
                         pythonDir != null
                         && Array.Exists(
                             config.mcpServers.unityMCP.args,
-                            arg => arg.Contains(pythonDir, StringComparison.Ordinal)
+                            arg => arg.Contains(comparisonPythonDir, StringComparison.Ordinal)
                         )
                     )
                     {


### PR DESCRIPTION
- Introduced Gemini CLI configuration in McpClients.cs with appropriate paths for Windows and Linux.
- Updated McpTypes.cs to include GeminiCli type.
- Enhanced UnityMcpEditorWindow.cs to convert Python directory paths to WSL format for Windows.
- Added PathConverter.cs for converting between Windows and WSL paths.