### PR TITLE
feat: Add Claude Code support with register/unregister toggle button in Unity MCP window

### DIFF
--- a/UnityMcpBridge/Editor/Data/McpClients.cs
+++ b/UnityMcpBridge/Editor/Data/McpClients.cs
@@ -29,6 +29,20 @@ namespace UnityMcpBridge.Editor.Data
             },
             new()
             {
+                name = "Claude Code",
+                windowsConfigPath = Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                    ".claude.json"
+                ),
+                linuxConfigPath = Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                    ".claude.json"
+                ),
+                mcpType = McpTypes.ClaudeCode,
+                configStatus = "Not Configured",
+            },
+            new()
+            {
                 name = "Cursor",
                 windowsConfigPath = Path.Combine(
                     Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
@@ -61,20 +75,6 @@ namespace UnityMcpBridge.Editor.Data
                     "settings.json"
                 ),
                 mcpType = McpTypes.VSCode,
-                configStatus = "Not Configured",
-            },
-            new()
-            {
-                name = "Claude Code",
-                windowsConfigPath = Path.Combine(
-                    Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-                    ".claude.json"
-                ),
-                linuxConfigPath = Path.Combine(
-                    Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-                    ".claude.json"
-                ),
-                mcpType = McpTypes.ClaudeCode,
                 configStatus = "Not Configured",
             },
         };

--- a/UnityMcpBridge/Editor/Data/McpClients.cs
+++ b/UnityMcpBridge/Editor/Data/McpClients.cs
@@ -63,6 +63,20 @@ namespace UnityMcpBridge.Editor.Data
                 mcpType = McpTypes.VSCode,
                 configStatus = "Not Configured",
             },
+            new()
+            {
+                name = "Claude Code",
+                windowsConfigPath = Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                    ".claude.json"
+                ),
+                linuxConfigPath = Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                    ".claude.json"
+                ),
+                mcpType = McpTypes.ClaudeCode,
+                configStatus = "Not Configured",
+            },
         };
 
         // Initialize status enums after construction

--- a/UnityMcpBridge/Editor/Models/McpTypes.cs
+++ b/UnityMcpBridge/Editor/Models/McpTypes.cs
@@ -5,6 +5,7 @@ namespace UnityMcpBridge.Editor.Models
         ClaudeDesktop,
         Cursor,
         VSCode,
+        ClaudeCode,
     }
 }
 

--- a/UnityMcpBridge/Editor/Windows/ManualConfigEditorWindow.cs
+++ b/UnityMcpBridge/Editor/Windows/ManualConfigEditorWindow.cs
@@ -39,7 +39,7 @@ namespace UnityMcpBridge.Editor.Windows
             );
             GUI.Label(
                 new Rect(titleRect.x + 10, titleRect.y + 6, titleRect.width - 20, titleRect.height),
-                mcpClient.name + " Manual Configuration",
+                (mcpClient?.name ?? "Unknown") + " Manual Configuration",
                 EditorStyles.boldLabel
             );
             EditorGUILayout.Space(10);
@@ -70,17 +70,17 @@ namespace UnityMcpBridge.Editor.Windows
             };
 
             EditorGUILayout.LabelField(
-                "1. Open " + mcpClient.name + " config file by either:",
+                "1. Open " + (mcpClient?.name ?? "Unknown") + " config file by either:",
                 instructionStyle
             );
-            if (mcpClient.mcpType == McpTypes.ClaudeDesktop)
+            if (mcpClient?.mcpType == McpTypes.ClaudeDesktop)
             {
                 EditorGUILayout.LabelField(
                     "    a) Going to Settings > Developer > Edit Config",
                     instructionStyle
                 );
             }
-            else if (mcpClient.mcpType == McpTypes.Cursor)
+            else if (mcpClient?.mcpType == McpTypes.Cursor)
             {
                 EditorGUILayout.LabelField(
                     "    a) Going to File > Preferences > Cursor Settings > MCP > Add new global MCP server",
@@ -96,16 +96,23 @@ namespace UnityMcpBridge.Editor.Windows
             // Path section with improved styling
             EditorGUILayout.BeginVertical(EditorStyles.helpBox);
             string displayPath;
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if (mcpClient != null)
             {
-                displayPath = mcpClient.windowsConfigPath;
-            }
-            else if (
-                RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
-                || RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
-            )
-            {
-                displayPath = mcpClient.linuxConfigPath;
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    displayPath = mcpClient.windowsConfigPath;
+                }
+                else if (
+                    RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
+                    || RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
+                )
+                {
+                    displayPath = mcpClient.linuxConfigPath;
+                }
+                else
+                {
+                    displayPath = configPath;
+                }
             }
             else
             {
@@ -224,7 +231,7 @@ namespace UnityMcpBridge.Editor.Windows
 
             EditorGUILayout.Space(10);
             EditorGUILayout.LabelField(
-                "3. Save the file and restart " + mcpClient.name,
+                "3. Save the file and restart " + (mcpClient?.name ?? "Unknown"),
                 instructionStyle
             );
 

--- a/UnityMcpBridge/Editor/Windows/UnityMcpEditorWindow.cs
+++ b/UnityMcpBridge/Editor/Windows/UnityMcpEditorWindow.cs
@@ -957,7 +957,7 @@ namespace UnityMcpBridge.Editor.Windows
                 process.WaitForExit();
 
 
-                
+
                 // Check for success or already exists
                 if (output.Contains("Added stdio MCP server") || errors.Contains("already exists"))
                 {
@@ -968,6 +968,7 @@ namespace UnityMcpBridge.Editor.Windows
                         CheckMcpConfiguration(claudeClient);
                     }
                     Repaint();
+                    UnityEngine.Debug.Log("UnityMCP server successfully registered from Claude Code.");
                     
 
                 }


### PR DESCRIPTION
- Added Claude Code as new MCP client type
- One-click registration via 'claude mcp add' command
- Toggle button to unregister when already configured
- Cross-platform support (Windows/macOS/Linux)
- Auto-detects configuration in ~/.claude.json

Fixes in 2nd commit:
- Enhanced FindUvPath() to return null when UV is not found
- Added detailed installation instructions for all platforms
- Implemented null checks in all UV usage points
- Added cross-platform path resolution for Windows, macOS, and Linux
- Improved user experience with clear error messages instead of silent failures
- Prevents 'spawn uv ENOENT' errors by using full paths and proper validation